### PR TITLE
Integration test script path fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 .DS_Store
 ._*
 
-# snakemake internal directory for tests
+# snakemake internal directories for tests
 tests/integration/execution/.snakemake/
+.snakemake/

--- a/tests/integration/config.yml
+++ b/tests/integration/config.yml
@@ -13,16 +13,16 @@
 ---
 
 # absolute path to the pipeline directory
-pipeline_path: "${TRAVIS_BUILD_DIR}"
+pipeline_path: "."
 
 # input sequence from the user
 sequence: "ATGTGAGTGAAGTGTGGGAAAGATGACTCGATATATCTGGATGCTAGGGATCGGATGGCGATACG"
 
 # path to the directory with TRANSFAC-formatted PWM files
-pwm_directory: "../pwm"
+pwm_directory: "tests/integration/pwm"
 
 # path for the output directory
-outdir: "../output"
+outdir: "tests/integration/output"
 
 # MotEvo parameter: prior probability for the background binding
 MotEvo_bg_binding_prior: 0.99

--- a/tests/integration/config.yml
+++ b/tests/integration/config.yml
@@ -12,6 +12,9 @@
 ###############################################################################
 ---
 
+# absolute path to the pipeline directory
+pipeline_path: "$TRAVIS_BUILD_DIR"
+
 # input sequence from the user
 sequence: "ATGTGAGTGAAGTGTGGGAAAGATGACTCGATATATCTGGATGCTAGGGATCGGATGGCGATACG"
 

--- a/tests/integration/config.yml
+++ b/tests/integration/config.yml
@@ -13,7 +13,7 @@
 ---
 
 # absolute path to the pipeline directory
-pipeline_path: "$TRAVIS_BUILD_DIR"
+pipeline_path: "${TRAVIS_BUILD_DIR}"
 
 # input sequence from the user
 sequence: "ATGTGAGTGAAGTGTGGGAAAGATGACTCGATATATCTGGATGCTAGGGATCGGATGGCGATACG"

--- a/tests/integration/config.yml
+++ b/tests/integration/config.yml
@@ -13,7 +13,7 @@
 ---
 
 # absolute path to the pipeline directory
-pipeline_path: "."
+pipeline_path: ""
 
 # input sequence from the user
 sequence: "ATGTGAGTGAAGTGTGGGAAAGATGACTCGATATATCTGGATGCTAGGGATCGGATGGCGATACG"

--- a/tests/integration/execution/snakemake_dag_run.sh
+++ b/tests/integration/execution/snakemake_dag_run.sh
@@ -24,4 +24,4 @@ snakemake \
     --verbose \
     --dag \
     | dot -Tsvg \
-    > ../../../images/dag.svg
+    > ./images/dag.svg

--- a/tests/integration/execution/snakemake_dag_run.sh
+++ b/tests/integration/execution/snakemake_dag_run.sh
@@ -13,12 +13,12 @@ set -u  # ensures that script exits when unset variables are used
 set -x  # facilitates debugging by printing out executed commands
 
 user_dir=$PWD
-pipeline_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-cd "$pipeline_dir"
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../../.."
+cd "$repo_dir"
 
 snakemake \
-    --snakefile="../../../workflow/Snakefile" \
-    --configfile="../config.yml" \
+    --snakefile="workflow/Snakefile" \
+    --configfile="tests/integration/config.yml" \
     --printshellcmds \
     --dryrun \
     --verbose \

--- a/tests/integration/execution/snakemake_local_run_conda_environments.sh
+++ b/tests/integration/execution/snakemake_local_run_conda_environments.sh
@@ -14,12 +14,12 @@ set -u  # ensures that script exits when unset variables are used
 set -x  # facilitates debugging by printing out executed commands
 
 user_dir=$PWD
-pipeline_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-cd "$pipeline_dir"
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../../.."
+cd "$repo_dir"
 
 snakemake \
-    --snakefile="../../../workflow/Snakefile" \
-    --configfile="../config.yml" \
+    --snakefile="workflow/Snakefile" \
+    --configfile="tests/integration/config.yml" \
     --use-conda \
     --cores=1 \
     --printshellcmds \

--- a/tests/integration/execution/snakemake_local_run_conda_environments.sh
+++ b/tests/integration/execution/snakemake_local_run_conda_environments.sh
@@ -23,5 +23,4 @@ snakemake \
     --use-conda \
     --cores=1 \
     --printshellcmds \
-    --verbose \
-    --force
+    --verbose

--- a/tests/integration/execution/snakemake_rulegraph_run.sh
+++ b/tests/integration/execution/snakemake_rulegraph_run.sh
@@ -13,12 +13,12 @@ set -u  # ensures that script exits when unset variables are used
 set -x  # facilitates debugging by printing out executed commands
 
 user_dir=$PWD
-pipeline_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-cd "$pipeline_dir"
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../../.."
+cd "$repo_dir"
 
 snakemake \
-    --snakefile="../../../workflow/Snakefile" \
-    --configfile="../config.yml" \
+    --snakefile="workflow/Snakefile" \
+    --configfile="tests/integration/config.yml" \
     --printshellcmds \
     --dryrun \
     --verbose \

--- a/tests/integration/execution/snakemake_rulegraph_run.sh
+++ b/tests/integration/execution/snakemake_rulegraph_run.sh
@@ -24,4 +24,4 @@ snakemake \
     --verbose \
     --rulegraph \
     | dot -Tsvg \
-    > ../../../images/rulegraph.svg
+    > ./images/rulegraph.svg

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -293,6 +293,12 @@ rule combine_MotEvo_results:
             ),
             outdir = config["outdir"],
             pwm_dir = gather_motifs_names(config["pwm_directory"])
+        ),
+        SCRIPT_ = os.path.join(
+            config["pipeline_path"],
+            "workflow",
+            "scripts",
+            "combine-motevo-results.py"
         )
 
     output:
@@ -312,7 +318,7 @@ rule combine_MotEvo_results:
 
     shell: 
         """
-        python ../../../workflow/scripts/combine-motevo-results.py \
+        python {input.SCRIPT_} \
         --input_directories {input.DIR_MotEvo_results_pwm} \
         --filename {params.STR_binding_sites_filename} \
         --outfile {output.TSV_combined_MotEvo_results}

--- a/workflow/config/config-template.yml
+++ b/workflow/config/config-template.yml
@@ -12,6 +12,9 @@
 ###############################################################################
 ---
 
+# absolute path to the pipeline directory
+pipeline_path:
+
 # input sequence from the user
 sequence:
 


### PR DESCRIPTION
## Description

We cannot hard-code paths within the `Snakefile` like: `python ../../../workflow/scripts/combine-motevo-results.py `   
I have fixed the problem with encoding the pipeline path into the `config.yml` file for *snakemake* (the user would have to provide it). Having this field we may encode in the `Snakefile` a relative path to the script from the `cwd` being the repository root directory.  

The issue required some minor changes in the integration tests bash scripts - from now on *snakemake* is being executed from the repository root directory as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage